### PR TITLE
Updating CFN templates to use a Node16 runtime

### DIFF
--- a/Abuse.ch/cfn-templates/ANFAbuseHostfile.yaml
+++ b/Abuse.ch/cfn-templates/ANFAbuseHostfile.yaml
@@ -100,7 +100,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to download the hostfile list from Abuse.ch daily

--- a/Abuse.ch/cfn-templates/AbuseCH.yaml
+++ b/Abuse.ch/cfn-templates/AbuseCH.yaml
@@ -120,7 +120,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to fetch data from the abuse.ch rule list and update the associated RuleGroup

--- a/Abuse.ch/cfn-templates/AbuseCHJA3.yaml
+++ b/Abuse.ch/cfn-templates/AbuseCHJA3.yaml
@@ -100,7 +100,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to fetch data from the abuse.ch rule list and update the associated RuleGroup

--- a/EmergingThreats/cfn-templates/EmergingThreatsBotCC.yaml
+++ b/EmergingThreats/cfn-templates/EmergingThreatsBotCC.yaml
@@ -97,7 +97,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to fetch data from the Emerging Threats Bot CC list and update the associated RuleGroup

--- a/EmergingThreats/cfn-templates/EmergingThreatsIPFiltering.yaml
+++ b/EmergingThreats/cfn-templates/EmergingThreatsIPFiltering.yaml
@@ -97,7 +97,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to fetch data from the Emerging Threats IP list and update the associated RuleGroup

--- a/SFTP-FQDN/templates/SFTP-FQDN.yaml
+++ b/SFTP-FQDN/templates/SFTP-FQDN.yaml
@@ -102,7 +102,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to fetch IPs for the given FQDN and update the associated RuleGroup

--- a/SpamHaus/cfn-templates/SpamHausDropIPFiltering.yaml
+++ b/SpamHaus/cfn-templates/SpamHausDropIPFiltering.yaml
@@ -97,7 +97,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to fetch data from the Emerging Threats IP list and update the associated RuleGroup

--- a/SpamHaus/cfn-templates/SpamHausEDropIPFiltering.yaml
+++ b/SpamHaus/cfn-templates/SpamHausEDropIPFiltering.yaml
@@ -97,7 +97,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to fetch data from the Emerging Threats IP list and update the associated RuleGroup

--- a/TLSFingerprint/cnf-templates/TLSFingerprint.yaml
+++ b/TLSFingerprint/cnf-templates/TLSFingerprint.yaml
@@ -114,7 +114,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 600
       Description: Used to check TLS server fingerprint and update the associated RuleGroup

--- a/TorProject/cfn-templates/TorProjectIPFiltering.yaml
+++ b/TorProject/cfn-templates/TorProjectIPFiltering.yaml
@@ -97,7 +97,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Handler: index.handler
       Timeout: 60
       Description: Used to fetch data from the Emerging Threats IP list and update the associated RuleGroup


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Updating the Lambda runtimes to use Node16


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
